### PR TITLE
Update for react-reconciler 0.26.1, add "color" prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,10 +6,11 @@ Monorepository holding a React library, and CLI tool for [CSG](https://en.wikipe
   <img src="./assets/screen.png">
 </p>
 
+The math is provided by the [@jscad/csg package](https://github.com/jscad/csg.js), please see it for more details and to understand the features/limitations of the approach. 3D output is intended for WebGL display or for STL export.
 
 ## `modeler-csg`
 
-Main library, a custom React [reconciler](https://reactjs.org/docs/reconciliation.html), designed to work with [`react-three-fiber`](https://github.com/drcmda/react-three-fiber).
+Main library, a custom React [reconciler](https://reactjs.org/docs/reconciliation.html), designed to work with [`react-three-fiber`](https://github.com/drcmda/react-three-fiber) and [Three.js](https://threejs.org/). Uses [@jscad/csg](https://github.com/jscad/csg.js) under the hood.
 
 ### Installation
 
@@ -64,6 +65,8 @@ API follows (for the most part) [@jscad/csg docs](https://github.com/jscad/csg.j
 - `<cylinder/>` - props: `start`, `end`, `radius`, `resolution`
 - `<roundedCylinder/>` - props: `start`, `end`, `radius`, `resolution`
 - `<ellipticCylinder/>` - props: `start`, `end`, `radius`, `radiusStart`, `radiusEnd`, `resolution`
+
+Each shape also supports a `color` prop that accepts `[0..1, 0..1, 0..1]` RGB values.
 
 #### Operations
 

--- a/packages/modeler-csg/src/reconciler.js
+++ b/packages/modeler-csg/src/reconciler.js
@@ -84,7 +84,7 @@ const createElement = (type, props) => {
 
 const createRootElement = () => {
   return {
-    type: 'ROOT',
+    type: "ROOT",
     content: null // only a single content node can exist
   };
 };
@@ -109,7 +109,7 @@ const CSGRenderer = new Reconciler({
   },
 
   createTextInstance() {
-    throw new Error('CSG modeler reconciler: text content not supported');
+    throw new Error("CSG modeler reconciler: text content not supported");
   },
 
   prepareUpdate() {},
@@ -118,10 +118,10 @@ const CSGRenderer = new Reconciler({
 
   noTimeout: -1,
   scheduleTimeout() {
-    throw new Error('CSG modeler reconciler: timeouts not supported');
+    throw new Error("CSG modeler reconciler: timeouts not supported");
   },
   cancelTimeout() {
-    throw new Error('CSG modeler reconciler: timeouts not supported');
+    throw new Error("CSG modeler reconciler: timeouts not supported");
   },
 
   createInstance(type, props) {
@@ -137,19 +137,19 @@ const CSGRenderer = new Reconciler({
   appendChild(parent, child) {
     // no subsequent mutations allowed
     throw new Error(
-      'CSG modeler reconciler: adding/removing children after first render is not supported'
+      "CSG modeler reconciler: adding/removing children after first render is not supported"
     );
   },
   removeChild(parent, child) {
     // no subsequent mutations allowed
     throw new Error(
-      'CSG modeler reconciler: adding/removing children after first render is not supported'
+      "CSG modeler reconciler: adding/removing children after first render is not supported"
     );
   },
 
   appendChildToContainer(parent, child) {
-    if (parent.type !== 'ROOT') {
-      throw new Error('CSG modeler reconciler: unexpected non-root container');
+    if (parent.type !== "ROOT") {
+      throw new Error("CSG modeler reconciler: unexpected non-root container");
     }
 
     if (parent.content === null) {

--- a/packages/modeler-csg/src/reconciler.js
+++ b/packages/modeler-csg/src/reconciler.js
@@ -22,7 +22,12 @@ const makeOp = op => {
 };
 
 const makeShape = (fnName, defaultProps = {}) => props => {
-  const csg = CSG[fnName]({ ...defaultProps, ...props });
+  const rawCSG = CSG[fnName]({ ...defaultProps, ...props });
+
+  const csg = props.color
+    ? rawCSG.setColor(props.color)
+    : rawCSG;
+
   return { csg };
 };
 

--- a/packages/modeler-csg/src/reconciler.js
+++ b/packages/modeler-csg/src/reconciler.js
@@ -138,7 +138,7 @@ const CSGRenderer = new Reconciler({
   },
 
   getPublicInstance(instance) {
-    return instance;
+    return instance.csg;
   },
 
   clearContainer() {

--- a/packages/modeler-csg/src/reconciler.js
+++ b/packages/modeler-csg/src/reconciler.js
@@ -26,53 +26,53 @@ const makeShape = (fnName, defaultProps = {}) => props => {
   return { csg };
 };
 
+const TYPES = {
+  ROOT: () => makeOp("union"),
+
+  sphere: makeShape("sphere", {
+    center: [0, 0, 0],
+    radius: 1,
+    resolution: 32
+  }),
+
+  cube: makeShape("cube", { center: [0, 0, 0], radius: [1, 1, 1] }),
+
+  roundedCube: makeShape("roundedCube", {
+    center: [0, 0, 0],
+    radius: [1, 1, 1],
+    roundradius: 0.1,
+    resolution: 32
+  }),
+
+  cylinder: makeShape("cylinder", {
+    start: [0, 0, 0],
+    end: [1, 0, 0],
+    radius: 1,
+    resolution: 32
+  }),
+
+  roundedCylinder: makeShape("roundedCylinder", {
+    start: [0, 0, 0],
+    end: [1, 0, 0],
+    radius: 1,
+    resolution: 32
+  }),
+
+  ellipticCylinder: makeShape("cylinderElliptic", {
+    start: [0, 0, 0],
+    end: [1, 0, 0],
+    radius: [1, 1],
+    radiusStart: [1, 1],
+    radiusEnd: [1, 1],
+    resolution: 32
+  }),
+
+  union: () => makeOp("union"),
+  subtract: () => makeOp("subtract"),
+  intersect: () => makeOp("intersect")
+};
+
 const createElement = (type, props) => {
-  const TYPES = {
-    ROOT: () => makeOp("union"),
-
-    sphere: makeShape("sphere", {
-      center: [0, 0, 0],
-      radius: 1,
-      resolution: 32
-    }),
-
-    cube: makeShape("cube", { center: [0, 0, 0], radius: [1, 1, 1] }),
-
-    roundedCube: makeShape("roundedCube", {
-      center: [0, 0, 0],
-      radius: [1, 1, 1],
-      roundradius: 0.1,
-      resolution: 32
-    }),
-
-    cylinder: makeShape("cylinder", {
-      start: [0, 0, 0],
-      end: [1, 0, 0],
-      radius: 1,
-      resolution: 32
-    }),
-
-    roundedCylinder: makeShape("roundedCylinder", {
-      start: [0, 0, 0],
-      end: [1, 0, 0],
-      radius: 1,
-      resolution: 32
-    }),
-
-    ellipticCylinder: makeShape("cylinderElliptic", {
-      start: [0, 0, 0],
-      end: [1, 0, 0],
-      radius: [1, 1],
-      radiusStart: [1, 1],
-      radiusEnd: [1, 1],
-      resolution: 32
-    }),
-
-    union: () => makeOp("union"),
-    subtract: () => makeOp("subtract"),
-    intersect: () => makeOp("intersect")
-  };
-
   const ret = TYPES[type](props);
   ret.type = type;
 

--- a/packages/modeler-csg/src/reconciler.js
+++ b/packages/modeler-csg/src/reconciler.js
@@ -86,7 +86,7 @@ const createRootElement = () => {
   return {
     type: 'ROOT',
     content: null // only a single content node can exist
-  }
+  };
 };
 
 const CSGRenderer = new Reconciler({
@@ -109,7 +109,7 @@ const CSGRenderer = new Reconciler({
   },
 
   createTextInstance() {
-    throw new Error('text not supported');
+    throw new Error('CSG modeler reconciler: text content not supported');
   },
 
   prepareUpdate() {},
@@ -118,10 +118,10 @@ const CSGRenderer = new Reconciler({
 
   noTimeout: -1,
   scheduleTimeout() {
-    throw new Error('timeouts not supported');
+    throw new Error('CSG modeler reconciler: timeouts not supported');
   },
   cancelTimeout() {
-    throw new Error('timeouts not supported');
+    throw new Error('CSG modeler reconciler: timeouts not supported');
   },
 
   createInstance(type, props) {
@@ -136,16 +136,20 @@ const CSGRenderer = new Reconciler({
 
   appendChild(parent, child) {
     // no subsequent mutations allowed
-    throw new Error('not supported');
+    throw new Error(
+      'CSG modeler reconciler: adding/removing children after first render is not supported'
+    );
   },
   removeChild(parent, child) {
     // no subsequent mutations allowed
-    throw new Error('not supported');
+    throw new Error(
+      'CSG modeler reconciler: adding/removing children after first render is not supported'
+    );
   },
 
   appendChildToContainer(parent, child) {
     if (parent.type !== 'ROOT') {
-      throw new Error('unexpected non-root container');
+      throw new Error('CSG modeler reconciler: unexpected non-root container');
     }
 
     if (parent.content === null) {

--- a/packages/modeler-csg/src/reconciler.js
+++ b/packages/modeler-csg/src/reconciler.js
@@ -27,8 +27,6 @@ const makeShape = (fnName, defaultProps = {}) => props => {
 };
 
 const TYPES = {
-  ROOT: () => makeOp("union"),
-
   sphere: makeShape("sphere", {
     center: [0, 0, 0],
     radius: 1,
@@ -77,6 +75,13 @@ const createElement = (type, props) => {
   ret.type = type;
 
   return ret;
+};
+
+const createRootElement = () => {
+  return {
+    type: 'ROOT',
+    content: null // only a single content node can exist
+  }
 };
 
 const CSGRenderer = new Reconciler({
@@ -134,7 +139,15 @@ const CSGRenderer = new Reconciler({
   },
 
   appendChildToContainer(parent, child) {
-    parent.appendChild(child);
+    if (parent.type !== 'ROOT') {
+      throw new Error('unexpected non-root container');
+    }
+
+    if (parent.content === null) {
+      parent.content = child.csg;
+    } else {
+      parent.content = parent.content.union(child.csg);
+    }
   },
 
   getPublicInstance(instance) {
@@ -147,6 +160,6 @@ const CSGRenderer = new Reconciler({
 });
 
 module.exports = {
-  createElement,
+  createRootElement,
   CSGRenderer
 };

--- a/packages/modeler-csg/src/reconciler.js
+++ b/packages/modeler-csg/src/reconciler.js
@@ -98,9 +98,21 @@ const CSGRenderer = new Reconciler({
     return false;
   },
 
-  prepareForCommit() {},
+  createTextInstance() {
+    throw new Error('text not supported');
+  },
 
+  prepareUpdate() {},
+  prepareForCommit() {},
   resetAfterCommit() {},
+
+  noTimeout: -1,
+  scheduleTimeout() {
+    throw new Error('timeouts not supported');
+  },
+  cancelTimeout() {
+    throw new Error('timeouts not supported');
+  },
 
   createInstance(type, props) {
     return createElement(type, props);
@@ -113,11 +125,12 @@ const CSGRenderer = new Reconciler({
   },
 
   appendChild(parent, child) {
-    parent.appendChild(child);
+    // no subsequent mutations allowed
+    throw new Error('not supported');
   },
-
   removeChild(parent, child) {
-    console.warn("removeChild not implemented!", { parent, child });
+    // no subsequent mutations allowed
+    throw new Error('not supported');
   },
 
   appendChildToContainer(parent, child) {
@@ -126,6 +139,10 @@ const CSGRenderer = new Reconciler({
 
   getPublicInstance(instance) {
     return instance;
+  },
+
+  clearContainer() {
+    // this is run on unmount, no-op
   }
 });
 


### PR DESCRIPTION
Hey, thanks for setting up this library!

I was trying to use it on a recent react-reconciler version and got an infinite loop crash - this PR adds a couple of missing callbacks that seem to be required in newer versions.

I also added a "color" prop that runs `setColor` on shapes. Finally, there was a bit of tweaking done to the root container instance, to allow convenience union logic.

By the way, I have a custom fork in my local repo that uses a "geometry" helper instead of the Model/Mesh helpers, so that it can be plugged into any arbitrary parent mesh with materials (but does not expose the intermediate "parts", just final polygons) - happy to share that too as it might add some flexibility.