### PR TITLE
Set up bare geometry generator, memoize more outputs

### DIFF
--- a/packages/modeler-csg/src/reconciler.js
+++ b/packages/modeler-csg/src/reconciler.js
@@ -32,6 +32,8 @@ const makeShape = (fnName, defaultProps = {}) => props => {
 };
 
 const TYPES = {
+  ROOT: () => makeOp("union"),
+
   sphere: makeShape("sphere", {
     center: [0, 0, 0],
     radius: 1,
@@ -80,13 +82,6 @@ const createElement = (type, props) => {
   ret.type = type;
 
   return ret;
-};
-
-const createRootElement = () => {
-  return {
-    type: "ROOT",
-    content: null // only a single content node can exist
-  };
 };
 
 const CSGRenderer = new Reconciler({
@@ -152,11 +147,7 @@ const CSGRenderer = new Reconciler({
       throw new Error("CSG modeler reconciler: unexpected non-root container");
     }
 
-    if (parent.content === null) {
-      parent.content = child.csg;
-    } else {
-      parent.content = parent.content.union(child.csg);
-    }
+    parent.appendChild(child);
   },
 
   getPublicInstance(instance) {
@@ -169,6 +160,6 @@ const CSGRenderer = new Reconciler({
 });
 
 module.exports = {
-  createRootElement,
+  createElement,
   CSGRenderer
 };

--- a/packages/modeler-csg/src/utils.js
+++ b/packages/modeler-csg/src/utils.js
@@ -1,9 +1,10 @@
-const { Geometry, Vector3, Face3 } = require("three");
+const { Geometry, Vector3, Face3, Color } = require("three");
 
 const geometryFromPolygons = polygons => {
   const geometry = new Geometry();
 
-  const getGeometryVertice = (geometry, v) => {
+  // @todo de-duplicate
+  const getGeometryVertice = (v) => {
     geometry.vertices.push(new Vector3(v.x, v.y, v.z));
     return geometry.vertices.length - 1;
   };
@@ -12,7 +13,7 @@ const geometryFromPolygons = polygons => {
     let vertices = [];
 
     for (let j = 0; j < polygons[i].vertices.length; j++) {
-      vertices.push(getGeometryVertice(geometry, polygons[i].vertices[j].pos));
+      vertices.push(getGeometryVertice(polygons[i].vertices[j].pos));
     }
 
     if (vertices[0] === vertices[vertices.length - 1]) {
@@ -20,11 +21,21 @@ const geometryFromPolygons = polygons => {
     }
 
     for (let j = 2; j < vertices.length; j++) {
+      const normal = polygons[i].plane.normal;
+      const color = polygons[i].shared.color;
+
       const face = new Face3(
         vertices[0],
         vertices[j - 1],
         vertices[j],
-        new Vector3().copy(polygons[i].plane.normal)
+        new Vector3(normal.x, normal.y, normal.z),
+        color
+          ? new Color(
+              ((color[0] * 255) << 16) |
+                ((color[1] * 255) << 8) |
+                (color[2] * 255)
+            )
+          : undefined
       );
 
       geometry.faces.push(face);


### PR DESCRIPTION
This proposal adds a simple geometry object helper that can be used instead of Model to attach to a custom r3f mesh. I.e. allows a more explicit usage in app code:

```jsx
<mesh castShadow etc-other-three-props>
  <Geometry>
    {/* main CSG definition as usual */}
    <cube radius={[1, 2, 1]} />
    {/* etc, etc */}
  </Geometry>

  <meshBasicMaterial etc-other-three-props />
</mesh>
```

Also, I noticed that my previous PR actually broke a couple things in existing library code (sorry!), so this should hopefully fix those. Would you mind running this on your local dev environment to see if there are any crashes? I am also not completely sure about the `parts` - they should work if you remove any existing root-level `<union>` tag (this changes the container to automatically behave as a union).

Oh, and I added useMemo/etc in a couple spots, too.

Happy to add docs if this approach does seem ok to you. Thanks!